### PR TITLE
truncate the bucket prefix to fit

### DIFF
--- a/input.tf
+++ b/input.tf
@@ -10,5 +10,7 @@ variable "redirect_to" {
 locals {
   records      = "${keys(transpose(var.domains))}"
   redirect_to = "${replace(var.redirect_to, "/^(?:https?://)?/", "https://")}"
-  bucket_name = "redirect-${replace(replace(local.redirect_to, "https://", ""), "/\\W/", "")}"
+  # truncate to 37 characters to fit the bucket_prefix limit
+  # https://groups.google.com/d/msg/terraform-tool/hhC5P4eIcVU/rdWiVfRvLgAJ
+  bucket_name = "${format("%.37s", "redirect-${replace(replace(local.redirect_to, "https://", ""), "/\\W/", "")}")}"
 }


### PR DESCRIPTION
Example:

```hcl
module "components_standards_usa_gov_redirect" {
  source = "mediapop/redirect/aws"
  version = "1.2.0"

  domains = {
    "usa.gov." = ["components.standards.usa.gov"]
  }

  redirect_to = "https://components.designsystem.digital.gov/"
}
```

This gives:

```
Error: module.components_standards_usa_gov_redirect.aws_s3_bucket.301: expected length of bucket_prefix to be in the range (0 - 37), got redirect-componentsdesignsystemdigitalgov
```

This change makes the `plan` succeed.

```hcl
module "components_standards_usa_gov_redirect" {
  source = "github.com/afeld/terraform-aws-redirect?ref=ba44014"

  domains = {
    "usa.gov." = ["components.standards.usa.gov"]
  }

  redirect_to = "https://components.designsystem.digital.gov/"
}
```